### PR TITLE
fix: enable simulator loop by setting API_ONLY=false

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - IS_PROD=true
       - LOG_LEVEL=info
       - LOG_PRETTY=true
-      - API_ONLY=true
+      - API_ONLY=false
       - EXECUTOR_ADDRESS=0xF177179963aA0EDE80Be4396d04d970171CF6a36
 
   othnode:


### PR DESCRIPTION
## Summary
- `API_ONLY=true` was introduced in commit 6b7758f (Oct 2025) during Othentic integration and never reverted
- This causes the simulator to **skip the entire simulation loop** — no chain sync, no workflow fetching, no simulations
- Every operator using this docker-compose as-is gets 0 workflows and 0% on the explorer
- Change `API_ONLY=true` → `API_ONLY=false` to restore normal simulator operation

## Impact
**Critical** — all operators who deployed using this repo after Oct 2025 are affected. Existing AWS nodes (deployed before the change) are unaffected because they predate the flag.

## Test plan
- [x] Verified on ditto-node-3 (46.101.248.12) — simulator now runs simulation loop and waits for indexer sync
- [x] Confirmed AWS nodes (runner-develop, runner-newprod) work correctly without this flag (pre-6b7758f)
- [x] Confirmed `API_ONLY=false` matches the default behavior when the flag is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)