### PR TITLE
Add restart policies to simulator, indexer, mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ If you don't have `make`, you can run the steps manually:
 docker compose up -d
 ```
 
+## Host Reliability
+
+All long-running services declare a Docker restart policy, so they come back after a container crash or host reboot. Two host-level settings are still required for that to work end-to-end:
+
+- Start Docker on boot: `sudo systemctl enable docker`
+- Cap container log size — Docker logs can fill the disk and silently kill the node. In `/etc/docker/daemon.json`:
+
+  ```json
+  { "log-driver": "json-file", "log-opts": { "max-size": "100m", "max-file": "3" } }
+  ```
+
+  then `sudo systemctl restart docker` (recreate containers with `docker compose up -d` for it to apply).
+
 ## Configuration
 
 The services are configured via environment variables. Critical secrets are loaded from the `.env` file, while other service-specific configurations are set directly in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   simulator:
     image: ghcr.io/dittonetwork/simulator:0.0.7
+    restart: unless-stopped
     networks:
       - ditto_network
     depends_on:
@@ -60,6 +61,7 @@ services:
 
   indexer:
     image: ghcr.io/dittonetwork/indexer:0.0.4
+    restart: unless-stopped
     networks:
       - ditto_network
     depends_on:
@@ -75,6 +77,7 @@ services:
 
   mongo:
     image: mongo:8.0.13
+    restart: unless-stopped
     command: mongod --replSet rs0 --bind_ip_all
     networks:
       - ditto_network


### PR DESCRIPTION
## Why

Only `othnode` had a `restart:` policy. A host reboot or Docker daemon restart permanently killed `simulator`, `indexer`, and `mongo` until someone noticed and intervened manually. This was the persistence mechanism behind the 2026-03-19 mainnet workflow-execution outage (guard heartbeat down ~3 months) and the multi-day execution gaps in February.

Since this compose file ships to all external operators, the fix benefits every deployment.

## What

- `restart: unless-stopped` on `simulator`, `indexer`, `mongo` (`othnode` keeps its existing `always`; `mongo-init` stays `"no"` — it's a one-shot replica-set init)
- README: new **Host Reliability** section — enable Docker on boot, and cap container log size in `/etc/docker/daemon.json` (known issue: Docker logs fill the disk and silently kill the node)

## Validation

- YAML parses cleanly; effective policies verified per service:
  `simulator=unless-stopped, othnode=always, indexer=unless-stopped, mongo=unless-stopped, mongo-init=no`
- No behavioral change while services run normally — policies only affect crash/reboot recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)